### PR TITLE
refactor: optimize user data retrieval by using loadCount

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -18,15 +18,17 @@ final readonly class UserController
 {
     public function show(User $user): JsonResponse
     {
+        $user->loadCount(['posts', 'followers', 'following']);
+
         return response()->json([
             'id' => $user->id,
             'username' => $user->username,
             'email' => $user->email,
             'email_verified' => $user->email_verified_at !== null,
             'created_at' => $user->created_at->toISOString(),
-            'posts_count' => $user->posts()->count(),
-            'followers_count' => $user->followers()->count(),
-            'following_count' => $user->following()->count(),
+            'posts_count' => $user->posts_count,
+            'followers_count' => $user->followers_count,
+            'following_count' => $user->following_count,
         ]);
     }
 


### PR DESCRIPTION
the `UserController::show()` method was executing 3 separate SQL queries to count user relationships (posts, followers, following).



after using `loadCount()` there is only one query

```
array:1 [
  0 => array:3 [
    "query" => "select "id", (select count(*) from "posts" where "users"."id" = "posts"."user_id") as "posts_count", (select count(*) from "users" as "laravel_reserved_0" inner join "followers" on "laravel_reserved_0"."id" = "followers"."follower_id" where "users"."id" = "followers"."user_id") as "followers_count", (select count(*) from "users" as "laravel_reserved_1" inner join "followers" on "laravel_reserved_1"."id" = "followers"."user_id" where "users"."id" = "followers"."follower_id") as "following_count" from "users" where "users"."id" in (1)"
    "bindings" => []
    "time" => 0.1
  ]
]
```